### PR TITLE
Add support for local script plugins to xxh

### DIFF
--- a/xxh_xxh/xxh.py
+++ b/xxh_xxh/xxh.py
@@ -1059,6 +1059,11 @@ class xxh:
 
             self.eprint(f'First run {self.shell} on {host}')
 
+        # Run pre_connect plugins
+        for local_plugin_dir in list(local_plugins_dir.glob(f'xxh-plugin-local-*')):
+            for local_plugin_name in list(local_plugin_dir.glob(f'pre_connect-*.py')):
+                exec(open(local_plugin_name).read())
+
         # Connect to host
 
         host_execute_file = host_execute_command = []
@@ -1122,3 +1127,7 @@ class xxh:
                     ssh_pipe_command=ssh_pipe_command
                 ))
 
+        # Run post_connect plugins
+        for local_plugin_dir in list(local_plugins_dir.glob(f'xxh-plugin-local-*')):
+            for local_plugin_name in list(local_plugin_dir.glob(f'post_connect-*.py')):
+                exec(open(local_plugin_name).read())


### PR DESCRIPTION
Related with https://github.com/xxh/xxh/issues/105

This is an idea to allow the user to create custom "plugins" for the xxh.py script on xxh connections, allowing us to upload or retrieve additional files, as well as execute python code **on local host** acording to something related with the xxh session.

Possibles uses?

- In my case, I would use this to automatically retrieve some logs generated during the xxh session and merge them with a local log.
- Someone could want to upload aditional files at the beggining of the session (from host, using sync or something, automatically)
- Soneone could require to execute some python code on ssh connection error (maybe it could be used for penetration testing or something like that, to try connection with different passwords or something)
....

I know this solution maybe is a little rude and we could probably make something more elegant, but this PR is a proof of concept just to know what do you think about the posibility of enabling this kind of plugin. Posibles alternatives etc.


This could be tested installing this example plugin: https://github.com/grg121/xxh-plugin-local-example 
